### PR TITLE
Add support for private repo via personal tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # terraform-registry
 This is a light weight Terraform Registry, more like a proxy.
-It currently only supports the `v1.provider` endpoint and Terraform provider releases hosted on Github. 
+It currently only supports the `v1.provider` endpoint and Terraform provider releases hosted on Github.
 
 # how it works
 The registry dynamically generates the correct response based on assets found in
@@ -46,10 +46,18 @@ https://github.com/philips-forks/terraform-provider-cloudfoundry/releases/tag/v0
 
 Notice the `signkey.asc` which is included in this release. You can use [Goreleaser](https://goreleaser.com/quick-start/) with this [.goreleaser.yml](https://github.com/hashicorp/terraform-provider-scaffolding/blob/master/.goreleaser.yml) template to create arbitrary releases of providers. The provider pointer also does not include the `terraform-provider-` prefix.
 
+# private repositories
+
+## authenticating via Personal Access Token
+
+1. Create token with `repo` scope [here](https://github.com/settings/tokens/new)
+
+  If you are using GitHub SSO for your organization, press `Enable SSO` button on your token and authorize it for this organization.
+
+2. Set token in `GITHUB_TOKEN` environment variable
+
 # current limitations and TODOs
-- Uses an anonymous Github client which has very low quota
 - Only supports providers
-- TODO: support Github PAT tokens
 
 # contact / getting help
 andy.lo-a-foe@philips.com

--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/google/go-github/v32 v32.1.0
 	github.com/labstack/echo/v4 v4.1.16
 	golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de
+	golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be
 )

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,7 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b h1:0mm1VjtFUOIlE1SbDlwjYaDxZVDP2S5ou6y0gSgXHu8=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be h1:vEDujvNQGv4jgYKudGeI/+DAX4Jffq6hpD55MmoEvKs=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
This PR adds support for downloading providers from private GitHub repos. But it can be also used to avoid API rate-limiting.