### PR TITLE
Add support for deploying to Heroku

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,7 +60,13 @@ func main() {
 	e.GET("/.well-known/terraform.json", serviceDiscoveryHandler())
 	e.GET("/v1/providers/:namespace/:type/*", client.providerHandler())
 
-	_ = e.Start(":8080")
+	port := os.Getenv("PORT")
+
+	if port == "" {
+		port = "8080"
+	}
+
+	_ = e.Start(fmt.Sprintf(":%s", port))
 }
 
 func serviceDiscoveryHandler() echo.HandlerFunc {


### PR DESCRIPTION
On Heroku, you have to use the `PORT` environment variable rather
than a port of your choice.  Prefer using that if available, else
default to 8080
